### PR TITLE
csrf_exmpt add to category url

### DIFF
--- a/tango_django/rango/views.py
+++ b/tango_django/rango/views.py
@@ -31,7 +31,7 @@ def about(request):
     return render_to_response('rango/about.html',dict1,context)
 
 
-
+@csrf_exempt
 def category(request,category_name_url):
     context = RequestContext(request)
     category_name = category_name_url.replace('_',' ')


### PR DESCRIPTION
By default django uses csrf middleware to check with cross site reference forgeing.